### PR TITLE
Options to run jobs w necessary environment *and* packages

### DIFF
--- a/R/runSelectionAsJob.R
+++ b/R/runSelectionAsJob.R
@@ -1,31 +1,45 @@
-runSelectionAsJob <- function() {
+runSelectionAsJob <- function(importEnv=TRUE, attachPackages=TRUE) {
 
   ## Get the document context.
   context <- rstudioapi::getActiveDocumentContext()$selection[[1]]$text
+
+  if(attachPackages) {
+    si=sessionInfo()
+    packages=names(si$otherPkgs)
+  }
 
   ## if not empty selection
   if (!is.null(context) && context != "") {
 
     ## save selection to a temporary file
     tf <- tempfile("dashJob", fileext = ".R")
-    writeLines(context, con = tf, sep = "\n")
+    tfc=file(tf, open='w')
+    if(attachPackages) {
+      writeLines("sapply(", con=tfc, )
+      dput(packages, file = tfc)
+      writeLines(",library, character.only=T)", con=tfc)
+    }
+    writeLines(context, con = tfc, sep = "\n")
+    writeLines("\n", con = tfc)
+    flush(tfc)
+
+    ## delete temporary file
+    on.exit({
+      ## allow time for scripting to start
+      Sys.sleep(5)
+      close(tfc)
+      unlink(tf)
+    }, add=T)
 
     ## run the temp script as a job, returning the
     ## results to the global environment
     .rs.api.runScriptJob(
       path = path.expand(tf),
-      importEnv = TRUE,
+      importEnv = importEnv,
       workingDir = getwd(),
       exportEnv = "R_GlobalEnv"
     )
 
   }
-
-  ## delete temporary file
-  on.exit({
-    ## allow time for scripting to start
-    Sys.sleep(5)
-    unlink(tf)
-  })
 
 }

--- a/R/runSelectionAsJob.R
+++ b/R/runSelectionAsJob.R
@@ -1,4 +1,4 @@
-runSelectionAsJob <- function(importEnv=TRUE, attachPackages=TRUE) {
+runSelectionAsJob <- function(importEnv=FALSE, attachPackages=FALSE) {
 
   ## Get the document context.
   context <- rstudioapi::getActiveDocumentContext()$selection[[1]]$text
@@ -42,4 +42,13 @@ runSelectionAsJob <- function(importEnv=TRUE, attachPackages=TRUE) {
 
   }
 
+}
+
+
+runSelectionAsJobWithEnv <- function() {
+  runSelectionAsJob(importEnv=TRUE, attachPackages=FALSE)
+}
+
+runSelectionAsJobWithEnvPackages <- function() {
+  runSelectionAsJob(importEnv=TRUE, attachPackages=TRUE)
 }

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -2,3 +2,15 @@ Name: Run as Job in Background
 Description: Runs the selection as a background Job.
 Binding: runSelectionAsJob
 Interactive: false
+
+Name: Run as Job with Environment
+Description: Runs the selection as a background Job importing objects from
+    original session.
+Binding: runSelectionAsJobWithEnv
+Interactive: false
+
+Name: Run as Job with Environment and Packages
+Description: Runs the selection as a background Job importing objects and
+    attaching packages from original session.
+Binding: runSelectionAsJobWithEnvPackages
+Interactive: false


### PR DESCRIPTION
This PR makes three different actions instead of one for the addin

- Run as Job in Background
- Run as Job with Environment
- Run as Job with Environment and Packages

The last one is normally what I want in order to run a snippet in the background since it also loads any attached packages. Note that Run as Job in Background would now run without the environment (which would be a change of behaviour from the current package), so they could perhaps be renamed

- Run as Job in Background
- Run as Job without Environment
- Run as Job with Environment and Packages

although the first option seems clearer to me.